### PR TITLE
Make console.log safer, use world in steps

### DIFF
--- a/features/console_output.feature
+++ b/features/console_output.feature
@@ -1,89 +1,33 @@
 Feature: Console output
 
-  Scenario: console output appears on the command line
-    Given the file "features/logging.feature" contains:
+  Scenario: console output appears in the main process output
+    Given a step definition includes the lines:
       """
-      Feature: Logging
-        Scenario: console.log
-          When I log some stuff
+      console.time()
+      console.info('[', 'console.info', ']')
+      console.warn('[', 'console.warn', ']')
+      console.error('[', 'console.error', ']')
+      console.log('[', 'console.log', ']')
+      console.log('[', 123, ']')
+      console.log('[', undefined, ']')
+      console.log('[', null, ']')
+      console.log('[', new Date('2000-01-01'), ']')
+      console.log('[', new Error('oops'), ']')
+      console.log('[', document.body, ']')
+      console.log('[', document.createTextNode('banana'), ']')
+      console.log('[', { x: document.createTextNode('apple') }, ']')
+      console.timeEnd()
       """
-    And the file "features/step_definitions/steps.js" contains:
-      """
-      const { defineSupportCode } = require('cucumber')
-      const assert = require('assert')
-
-      defineSupportCode(function ({ When }) {
-        When(/^I log some stuff$/, function () {
-          console.info("console.info ->", 'info')
-          console.warn("console.warn ->", new Date('2000-01-01'))
-          console.error("console.error ->", new Error("oops"))
-          console.log("console.log ->", 123)
-        })
-      })
-      """
-    When I run `cucumber-electron`
-    Then the output should include:
-      """
-        Scenario: console.log
-      console.info -> info
-      console.warn -> [Date: 2000-01-01T00:00:00.000Z]
-      console.error -> [Error: oops]
-      console.log -> 123
-        ✔ When I log some stuff
-      """
-
-  Scenario: console converts DOM nodes to strings
-    Given the file "features/logging.feature" contains:
-      """
-      Feature: Logging an element
-        Scenario: console.log converts elements to strings
-          When I log DOM nodes
-      """
-    And the file "features/step_definitions/steps.js" contains:
-      """
-      const { defineSupportCode } = require('cucumber')
-      const assert = require('assert')
-
-      defineSupportCode(function ({ When }) {
-        When(/^I log DOM nodes$/, function () {
-          const iframe = document.createElement('iframe')
-          document.body.appendChild(iframe)
-          const textNode = document.createTextNode('hello')
-          console.log(document.body, document.head, iframe)
-          console.log(textNode, { x: textNode, y: { z: textNode } }, '!')
-        })
-      })
-      """
-    When I run `cucumber-electron`
-    Then the output should include:
-      """
-      <body /> <head /> <iframe />
-      [TextNode:hello] { x: [TextNode:hello], y: { z: [TextNode:hello] } } !
-      """
-
-  Scenario: console does not clobber timeEnd etc
-    Given the file "features/logging.feature" contains:
-      """
-      Feature: Logging timeEnd
-        Scenario: console.log converts elements to strings
-          When I call console.timeEnd
-      """
-    And the file "features/step_definitions/steps.js" contains:
-      """
-      const { defineSupportCode } = require('cucumber')
-      const assert = require('assert')
-
-      defineSupportCode(function ({ When }) {
-        When('I call console.timeEnd', function () {
-          console.log("before")
-          console.timeEnd()
-          console.log("after")
-        })
-      })
-      """
-    When I run `cucumber-electron`
-    Then the output should include:
-      """
-      before
-      after
-      """
+    When I run a scenario with that step
+    Then stdout should include "[ console.info ]"
+    And stderr should include "[ console.warn ]"
+    And stderr should include "[ console.error ]"
+    And stdout should include "[ console.log ]"
+    And stdout should include "[ 123 ]"
+    And stdout should include "[ [undefined] ]"
+    And stdout should include "[ [null] ]"
+    And stdout should include "[ [Date: 2000-01-01T00:00:00.000Z] ]"
+    And stdout should include "[ [Error: oops] ]"
+    And stdout should include "[ <body /> ]"
+    And stdout should include "[ [TextNode:banana] ]"
+    And stdout should include "[ { x: [TextNode:apple] } ]"

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -1,103 +1,57 @@
-const os = require('os')
-const path = require('path')
-const assert = require('assert')
-const fs = require('fs-promise')
-const mkdirp = require('mkdirp-promise')
-const rmfr = require('rmfr')
-const colors = require('colors')
 const { defineSupportCode } = require('cucumber')
 
-const { spawn } = require('child_process')
-const tempDir = path.resolve(__dirname + '/../../tmp')
-
-defineSupportCode(function ({ Given, When, Then, Before, setDefaultTimeout }) {
-  if (os.platform() === 'win32') {
-    setDefaultTimeout(15000)
-  }
-
-  Before(() => rmfr(tempDir).then(() => mkdirp(tempDir)))
-
+defineSupportCode(function ({ Given, When, Then }) {
   Given('the file {filePath:stringInDoubleQuotes} contains:', function (filePath, contents) {
-    const dir = path.resolve(path.join(tempDir, path.dirname(filePath)))
-    return mkdirp(dir).then(() => fs.writeFile(path.join(tempDir, filePath), contents))
+    return this.writeFile(filePath, contents)
+  })
+
+  Given('a step definition includes the lines:', function (lines) {
+    const contents = [
+      'const { defineSupportCode } = require(\'cucumber\')',
+      'defineSupportCode(function ({ When }) {',
+      '  When(\'I run that step\', function() {'
+    ]
+    .concat(lines.split('\n').map(line => '    ' + line))
+    .concat([
+      '  })',
+      '})'
+    ]).join('\n')
+    return this.writeFile('features/step_definitions/steps.js', contents)
+  })
+
+  When('I run a scenario with that step', function () {
+    const contents = [
+      'Feature: With that step',
+      '  Scenario: Running that step',
+      '    When I run that step'
+    ].join('\n')
+    return this.writeFile('features/with_that_step.feature', contents)
+      .then(() => {
+        return this.runCommand('cucumber-electron features/with_that_step.feature')
+      })
   })
 
   When('I run `{command}`', function (command) {
-    const args = command.split(' ')
-    args[0] = args[0].replace(/^cucumber-electron/, 'cucumber-electron.js')
-    args[0] = path.resolve(__dirname + '/../../bin/' + args[0])
-
-    return new Promise((resolve, reject) => {
-      this.execResult = { stdout: '', stderr: '', output: '', exitCode: null }
-      this.printExecResult = () =>
-        '------------------------------------\n' +
-        `The process exited with code ${this.spawnedProcess.exitCode}\n` +
-        '------------------------------------\n' +
-        `OUTPUT:\n${this.execResult.output}\n` +
-        '------------------------------------\n' +
-        `STDOUT:\n${this.execResult.stdout}\n` +
-        '------------------------------------\n' +
-        `STDERR:\n${this.execResult.stderr}\n` +
-        '------------------------------------\n'
-
-      this.spawnedProcess = spawn('node', args, { cwd: tempDir })
-
-      this.spawnedProcess.stdout.on('data', chunk => {
-        this.execResult.stdout += chunk.toString()
-        this.execResult.output += chunk.toString()
-      })
-      this.spawnedProcess.stderr.on('data', chunk => {
-        this.execResult.stderr += chunk.toString()
-        this.execResult.output += chunk.toString()
-      })
-      this.spawnedProcess.on('error', e => {
-        reject(e)
-      })
-      this.spawnedProcess.on('exit', code => this.execResult.exitCode = code)
-      resolve()
-    })
+    return this.runCommand(command)
   })
 
   Then('the process should exit with code {exitCode:int}', function (exitCode) {
-    return new Promise(resolve => {
-      this.spawnedProcess.on('exit', () => {
-        assert.equal(this.spawnedProcess.exitCode, exitCode, this.printExecResult())
-        resolve()
-      })
-    })
+    return this.assertProcessExitedWithCode(exitCode)
   })
 
   Then('the process should not exit', function () {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        const exitCode = this.spawnedProcess.exitCode
-        if (os.platform() === 'win32') {
-          spawn('taskkill', ['/pid', this.spawnedProcess.pid, '/T', '/F'])
-        } else {
-          // +1 because we are spawning node, which is the parent process
-          // https://github.com/nodejs/node/issues/2098
-          process.kill(this.spawnedProcess.pid + 1)
-        }
-        if (exitCode === null) {
-          resolve()
-        } else {
-          reject('The process exited unexpectedly\n' + this.printExecResult())
-        }
-      }, 500)
-    })
+    return this.assertProcessDidNotExit()
   })
 
   Then('the output should include:', function (expectedOutput) {
-    return new Promise((resolve, reject) => {
-      this.spawnedProcess.on('exit', () => {
-        const normalisedExpectedOutput = expectedOutput.replace('\r\n', '\n')
-        const normalisedActualOutput = colors.strip(this.execResult.output).replace('\r\n', '\n')
-        if (normalisedActualOutput.indexOf(normalisedExpectedOutput) == -1) {
-          reject(new Error(`Expected output to include:\n${normalisedExpectedOutput}\n` +
-            this.printExecResult()))
-        }
-        resolve()
-      })
-    })
+    return this.assertOutputIncludes(expectedOutput)
+  })
+
+  Then('stdout should include {arg1:stringInDoubleQuotes}', function (expectedOutput) {
+    return this.assertStdoutIncludes(expectedOutput)
+  })
+
+  Then('stderr should include {arg1:stringInDoubleQuotes}', function (expectedOutput) {
+    return this.assertStderrIncludes(expectedOutput)
   })
 })

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,0 +1,134 @@
+const { spawn } = require('child_process')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
+const assert = require('assert')
+const mkdirp = require('mkdirp-promise')
+const rmfr = require('rmfr')
+const colors = require('colors')
+
+const { defineSupportCode } = require('cucumber')
+
+class CucumberElectronWorld {
+  constructor() {
+    this.tempDir = path.resolve(__dirname + '/../../tmp')
+  }
+
+  writeFile(filePath, contents) {
+    const dir = path.resolve(path.join(this.tempDir, path.dirname(filePath)))
+    return mkdirp(dir).then(() => {
+      return new Promise((resolve, reject) => {
+        fs.writeFile(path.join(this.tempDir, filePath), contents, err =>
+          err ? reject(err) : resolve(err)
+        )
+      })
+    })
+  }
+
+  runCommand(command) {
+    const args = command.split(' ')
+    args[0] = args[0].replace(/^cucumber-electron/, 'cucumber-electron.js')
+    args[0] = path.resolve(__dirname + '/../../bin/' + args[0])
+
+    return new Promise((resolve, reject) => {
+      this.execResult = { stdout: '', stderr: '', output: '', exitCode: null }
+      this.printExecResult = () =>
+        '------------------------------------\n' +
+        `The process exited with code ${this.spawnedProcess.exitCode}\n` +
+        '------------------------------------\n' +
+        `OUTPUT:\n${this.execResult.output}\n` +
+        '------------------------------------\n' +
+        `STDOUT:\n${this.execResult.stdout}\n` +
+        '------------------------------------\n' +
+        `STDERR:\n${this.execResult.stderr}\n` +
+        '------------------------------------\n'
+
+      this.spawnedProcess = spawn('node', args, { cwd: this.tempDir })
+
+      this.spawnedProcess.stdout.on('data', chunk => {
+        this.execResult.stdout += chunk.toString()
+        this.execResult.output += chunk.toString()
+      })
+      this.spawnedProcess.stderr.on('data', chunk => {
+        this.execResult.stderr += chunk.toString()
+        this.execResult.output += chunk.toString()
+      })
+      this.spawnedProcess.on('error', e => {
+        reject(e)
+      })
+      this.spawnedProcess.on('exit', code => this.execResult.exitCode = code)
+      resolve()
+    })
+  }
+
+  ensureProcessHasExited() {
+    if (this.spawnedProcess.exitCode == null) {
+      return new Promise(resolve => {
+        this.spawnedProcess.on('exit', code => {
+          this.execResult.exitCode = code
+          resolve()
+        })
+      })
+    }
+    return Promise.resolve()
+  }
+
+  assertProcessDidNotExit() {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        const exitCode = this.spawnedProcess.exitCode
+        if (os.platform() === 'win32') {
+          spawn('taskkill', ['/pid', this.spawnedProcess.pid, '/T', '/F'])
+        } else {
+          // +1 because we are spawning node, which is the parent process
+          // https://github.com/nodejs/node/issues/2098
+          process.kill(this.spawnedProcess.pid + 1)
+        }
+        if (exitCode === null) {
+          resolve()
+        } else {
+          reject('The process exited unexpectedly\n' + this.printExecResult())
+        }
+      }, 500)
+    })
+  }
+
+  assertProcessExitedWithCode(expectedExitCode) {
+    return new Promise(resolve => {
+      this.spawnedProcess.on('exit', () => {
+        assert.equal(this.spawnedProcess.exitCode, expectedExitCode, this.printExecResult())
+        resolve()
+      })
+    })
+  }
+
+  assertOutputIncludes(expectedOutput, stream = 'output') {
+    return this.ensureProcessHasExited().then(() => {
+      const normalisedExpectedOutput = expectedOutput.replace('\r\n', '\n')
+      const normalisedActualOutput = colors.strip(this.execResult[stream]).replace('\r\n', '\n')
+      if (normalisedActualOutput.indexOf(normalisedExpectedOutput) == -1) {
+        throw new Error(`Expected ${stream} to include:\n${normalisedExpectedOutput}\n` +
+          this.printExecResult())
+      }
+    })
+  }
+
+  assertStdoutIncludes(expectedOutput) {
+    return this.assertOutputIncludes(expectedOutput, 'stdout')
+  }
+
+  assertStderrIncludes(expectedOutput) {
+    return this.assertOutputIncludes(expectedOutput, 'stderr')
+  }
+}
+
+defineSupportCode(function ({ setWorldConstructor, setDefaultTimeout, Before }) {
+  if (os.platform() === 'win32') {
+    setDefaultTimeout(15000)
+  }
+
+  setWorldConstructor(CucumberElectronWorld)
+
+  Before(function () { return rmfr(this.tempDir) })
+  Before(function () { return mkdirp(this.tempDir) })
+})

--- a/renderer/patches/console.js
+++ b/renderer/patches/console.js
@@ -7,7 +7,11 @@ const localConsole = console
 global.console = {}
 
 function ipcSafe(arg) {
-  if (arg.nodeType === 1 && typeof arg.tagName === 'string') {
+  if (typeof arg === 'undefined') {
+    return '[undefined]'
+  } else if (arg === null) {
+    return '[null]'
+  } else if (arg.nodeType === 1 && typeof arg.tagName === 'string') {
     return `<${arg.tagName.toLowerCase()} />`
   } else if (arg.nodeType === 3 && typeof arg.wholeText === 'string') {
     return `[TextNode:${arg.wholeText}]`


### PR DESCRIPTION
This makes console.log(undefined) not blow up, and refactors steps so they can make multiple asserts about output, and assert about stdout/stderr independently.
