### PR TITLE
Open devtools automatically in debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { join, resolve } = require('path')
 const window = require('electron-window')
-const { app } = require('electron')
+const { app, ipcMain: ipc } = require('electron')
 app.commandLine.appendSwitch('--disable-http-cache')
 
 const Options = require('./cli/options')
@@ -10,11 +10,30 @@ let win
 
 app.on('ready', () => {
   win = window.createWindow({
-    height: 800,
-    width: 600,
+    height: 900,
+    width: 1000,
     focusable: options.electronDebug,
-    show: options.electronDebug,
+    show: false,
     webPreferences: { webSecurity: false }
+  })
+
+  win.webContents.once('did-finish-load', () => {
+    if (options.electronDebug) {
+      win.show()
+      win.webContents.openDevTools()
+      win.webContents.on('devtools-opened', () => {
+        // Debugger is not immediately ready
+        setTimeout(() => {
+          win.webContents.send('run-cucumber')
+          // after the first run, reloading the electron window re-runs cucumber
+          ipc.on('ready-to-run-cucumber', () => {
+            win.webContents.send('run-cucumber')
+          })
+        }, 250)
+      })
+    } else {
+      win.webContents.send('run-cucumber')
+    }
   })
 
   if (!options.electronDebug && process.platform === 'darwin') {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -11,6 +11,8 @@ const Output = require('./output')
 const output = new Output()
 const options = new Options(electron.remote.process.argv)
 
+const { ipcRenderer: ipc } = require('electron')
+
 process.on('unhandledRejection', function (reason) {
   output.write(reason.message + '\\n' + reason.stack)
   exitWithCode(3)
@@ -20,13 +22,17 @@ function exitWithCode(code) {
   if (!options.electronDebug) electron.remote.process.exit(code)
 }
 
-try {
-  const argv = options.cucumberArgv
-  const cwd = process.cwd()
-  const stdout = new Output()
-  new Cucumber.Cli({ argv, cwd, stdout }).run()
-    .then(pass => exitWithCode(pass ? 0 : 1))
-} catch (err) {
-  output.write(err.stack + '\\n')
-  exitWithCode(2)
-}
+ipc.on('run-cucumber', () => {
+  try {
+    const argv = options.cucumberArgv
+    const cwd = process.cwd()
+    const stdout = new Output()
+    new Cucumber.Cli({ argv, cwd, stdout }).run()
+      .then(pass => exitWithCode(pass ? 0 : 1))
+  } catch (err) {
+    output.write(err.stack + '\\n')
+    exitWithCode(2)
+  }
+})
+
+ipc.send('ready-to-run-cucumber')


### PR DESCRIPTION
Automatically opens the chrome devtools when running with `--electron-debug` and defers running cucumber until the devtools are opened and ready for debugging.

This means adding a `debugger` statement somewhere in your step definitions should pause execution and open the sources tab in the devtools.

The chrome dev tools will persist breakpoints between runs. However there appears to be a bug in electron where the first persisted breakpoint will not be hit after opening the dev tools for the first time. Reloading the window re-runs cucumber and all breakpoints are hit.