### PR TITLE
Demonstrate multiple sessions in iframes

### DIFF
--- a/cucumber
+++ b/cucumber
@@ -1,1 +1,1 @@
-./node_modules/.bin/cucumber.js "$@"
+./node_modules/.bin/cucumber.js --tags 'not @only-runs-in-cucumber-electron' "$@"

--- a/features/multiple_sessions.feature
+++ b/features/multiple_sessions.feature
@@ -1,0 +1,6 @@
+Feature: Multiple Sessions
+
+  Scenario: Hosting the same web app in multiple frames
+    Given a web app is running
+    When I load the app on different hostnames in two separate frames
+    Then they should have independent sessions

--- a/features/multiple_sessions.feature
+++ b/features/multiple_sessions.feature
@@ -1,5 +1,6 @@
 Feature: Multiple Sessions
 
+  @only-runs-in-cucumber-electron
   Scenario: Hosting the same web app in multiple frames
     Given a web app is running
     When I load the app on different hostnames in two separate frames

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -19,6 +19,27 @@ defineSupportCode(function ({ Given, When, Then }) {
     return this.writeFile('features/step_definitions/steps.js', contents)
   })
 
+  Given('a web app is running', function () {
+    return this.runWebApp()
+  })
+
+  When('I load the app on different hostnames in two separate frames', function () {
+    return Promise.all([
+      this.loadWebAppInIFrame('http://localhost:8666'),
+      this.loadWebAppInIFrame('http://127.0.0.1:8666')
+    ]).then(frames => {
+      this.frames = frames
+    })
+  })
+
+  Then('they should have independent sessions', function () {
+    return Promise.all(this.frames.map(frame => this.reloadFrame(frame)))
+      .then(() => {
+        this.assertFrameIsInSession(this.frames[0], 1)
+        this.assertFrameIsInSession(this.frames[1], 2)
+      })
+  })
+
   When('I run a scenario with that step', function () {
     const contents = [
       'Feature: With that step',

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,133 +1,46 @@
-const { spawn } = require('child_process')
-const path = require('path')
-const fs = require('fs')
 const os = require('os')
-const assert = require('assert')
-const mkdirp = require('mkdirp-promise')
-const rmfr = require('rmfr')
-const colors = require('colors')
+
+const worlds = [
+  require('./worlds/processes'),
+  require('./worlds/webApps')
+]
 
 const { defineSupportCode } = require('cucumber')
 
-class CucumberElectronWorld {
-  constructor() {
-    this.tempDir = path.resolve(__dirname + '/../../tmp')
-  }
-
-  writeFile(filePath, contents) {
-    const dir = path.resolve(path.join(this.tempDir, path.dirname(filePath)))
-    return mkdirp(dir).then(() => {
-      return new Promise((resolve, reject) => {
-        fs.writeFile(path.join(this.tempDir, filePath), contents, err =>
-          err ? reject(err) : resolve(err)
-        )
-      })
-    })
-  }
-
-  runCommand(command) {
-    const args = command.split(' ')
-    args[0] = args[0].replace(/^cucumber-electron/, 'cucumber-electron.js')
-    args[0] = path.resolve(__dirname + '/../../bin/' + args[0])
-
-    return new Promise((resolve, reject) => {
-      this.execResult = { stdout: '', stderr: '', output: '', exitCode: null }
-      this.printExecResult = () =>
-        '------------------------------------\n' +
-        `The process exited with code ${this.spawnedProcess.exitCode}\n` +
-        '------------------------------------\n' +
-        `OUTPUT:\n${this.execResult.output}\n` +
-        '------------------------------------\n' +
-        `STDOUT:\n${this.execResult.stdout}\n` +
-        '------------------------------------\n' +
-        `STDERR:\n${this.execResult.stderr}\n` +
-        '------------------------------------\n'
-
-      this.spawnedProcess = spawn('node', args, { cwd: this.tempDir })
-
-      this.spawnedProcess.stdout.on('data', chunk => {
-        this.execResult.stdout += chunk.toString()
-        this.execResult.output += chunk.toString()
-      })
-      this.spawnedProcess.stderr.on('data', chunk => {
-        this.execResult.stderr += chunk.toString()
-        this.execResult.output += chunk.toString()
-      })
-      this.spawnedProcess.on('error', e => {
-        reject(e)
-      })
-      this.spawnedProcess.on('exit', code => this.execResult.exitCode = code)
-      resolve()
-    })
-  }
-
-  ensureProcessHasExited() {
-    if (this.spawnedProcess.exitCode == null) {
-      return new Promise(resolve => {
-        this.spawnedProcess.on('exit', code => {
-          this.execResult.exitCode = code
-          resolve()
-        })
-      })
-    }
-    return Promise.resolve()
-  }
-
-  assertProcessDidNotExit() {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        const exitCode = this.spawnedProcess.exitCode
-        if (os.platform() === 'win32') {
-          spawn('taskkill', ['/pid', this.spawnedProcess.pid, '/T', '/F'])
-        } else {
-          // +1 because we are spawning node, which is the parent process
-          // https://github.com/nodejs/node/issues/2098
-          process.kill(this.spawnedProcess.pid + 1)
-        }
-        if (exitCode === null) {
-          resolve()
-        } else {
-          reject('The process exited unexpectedly\n' + this.printExecResult())
-        }
-      }, 500)
-    })
-  }
-
-  assertProcessExitedWithCode(expectedExitCode) {
-    return this.ensureProcessHasExited().then(() => {
-      assert.equal(this.spawnedProcess.exitCode, expectedExitCode, this.printExecResult())
-    })
-  }
-
-  assertOutputIncludes(expectedOutput, stream = 'output') {
-    return this.ensureProcessHasExited().then(() => {
-      const normalisedExpectedOutput = expectedOutput.replace('\r\n', '\n')
-      const normalisedActualOutput = colors.strip(this.execResult[stream]).replace('\r\n', '\n')
-      if (normalisedActualOutput.indexOf(normalisedExpectedOutput) == -1) {
-        throw new Error(`Expected ${stream} to include:\n${normalisedExpectedOutput}\n` +
-          this.printExecResult())
+function CucumberElectronWorld() {
+  this.worlds = worlds.map(World => {
+    const world = new World()
+    for (let key of Reflect.ownKeys(Reflect.getPrototypeOf(world))) {
+      if (['constructor', 'start', 'stop'].indexOf(key) == -1) {
+        this[key] = world[key]
       }
-    })
-  }
-
-  assertStdoutIncludes(expectedOutput) {
-    return this.assertOutputIncludes(expectedOutput, 'stdout')
-  }
-
-  assertStderrIncludes(expectedOutput) {
-    // On windows, everything goes out of stderr. Electron.exe needs a shim, or something
-    const errorStream = os.platform() === 'win32' ? 'stdout' : 'stderr'
-    return this.assertOutputIncludes(expectedOutput, errorStream)
-  }
+    }
+    for (let key in world) {
+      this[key] = world[key]
+    }
+    return world
+  })
 }
 
-defineSupportCode(function ({ setWorldConstructor, setDefaultTimeout, Before }) {
+CucumberElectronWorld.prototype.startWorlds = function () {
+  return Promise.all(this.worlds.map(world => {
+    return world.start ? world.start.apply(this) : Promise.resolve()
+  }))
+}
+
+CucumberElectronWorld.prototype.stopWorlds = function () {
+  return Promise.all(this.worlds.map(world => {
+    return world.stop ? world.stop.apply(this) : Promise.resolve()
+  }))
+}
+
+defineSupportCode(function ({ setWorldConstructor, setDefaultTimeout, Before, After }) {
   if (os.platform() === 'win32') {
     setDefaultTimeout(15000)
   }
 
   setWorldConstructor(CucumberElectronWorld)
 
-  Before(function () { return rmfr(this.tempDir) })
-  Before(function () { return mkdirp(this.tempDir) })
+  Before(function () { return this.startWorlds() })
+  After(function () { return this.stopWorlds() })
 })

--- a/features/support/worlds/processes.js
+++ b/features/support/worlds/processes.js
@@ -1,0 +1,126 @@
+const { spawn } = require('child_process')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
+const assert = require('assert')
+const mkdirp = require('mkdirp-promise')
+const rmfr = require('rmfr')
+const colors = require('colors')
+
+class Processes {
+  constructor() {
+    this.tempDir = path.resolve(__dirname + '/../../../tmp')
+  }
+
+  start() {
+    return rmfr(this.tempDir).then(() => mkdirp(this.tempDir))
+  }
+
+  writeFile(filePath, contents) {
+    const dir = path.resolve(path.join(this.tempDir, path.dirname(filePath)))
+    return mkdirp(dir).then(() => {
+      return new Promise((resolve, reject) => {
+        fs.writeFile(path.join(this.tempDir, filePath), contents, err =>
+          err ? reject(err) : resolve(err)
+        )
+      })
+    })
+  }
+
+  runCommand(command) {
+    const args = command.split(' ')
+    args[0] = args[0].replace(/^cucumber-electron/, 'cucumber-electron.js')
+    args[0] = path.resolve(__dirname + '/../../../bin/' + args[0])
+
+    return new Promise((resolve, reject) => {
+      this.execResult = { stdout: '', stderr: '', output: '', exitCode: null }
+      this.printExecResult = () =>
+        '------------------------------------\n' +
+        `The process exited with code ${this.spawnedProcess.exitCode}\n` +
+        '------------------------------------\n' +
+        `OUTPUT:\n${this.execResult.output}\n` +
+        '------------------------------------\n' +
+        `STDOUT:\n${this.execResult.stdout}\n` +
+        '------------------------------------\n' +
+        `STDERR:\n${this.execResult.stderr}\n` +
+        '------------------------------------\n'
+
+      this.spawnedProcess = spawn('node', args, { cwd: this.tempDir })
+
+      this.spawnedProcess.stdout.on('data', chunk => {
+        this.execResult.stdout += chunk.toString()
+        this.execResult.output += chunk.toString()
+      })
+      this.spawnedProcess.stderr.on('data', chunk => {
+        this.execResult.stderr += chunk.toString()
+        this.execResult.output += chunk.toString()
+      })
+      this.spawnedProcess.on('error', e => {
+        reject(e)
+      })
+      this.spawnedProcess.on('exit', code => this.execResult.exitCode = code)
+      resolve()
+    })
+  }
+
+  ensureProcessHasExited() {
+    if (this.spawnedProcess.exitCode == null) {
+      return new Promise(resolve => {
+        this.spawnedProcess.on('exit', code => {
+          this.execResult.exitCode = code
+          resolve()
+        })
+      })
+    }
+    return Promise.resolve()
+  }
+
+  assertProcessDidNotExit() {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        const exitCode = this.spawnedProcess.exitCode
+        if (os.platform() === 'win32') {
+          spawn('taskkill', ['/pid', this.spawnedProcess.pid, '/T', '/F'])
+        } else {
+          // +1 because we are spawning node, which is the parent process
+          // https://github.com/nodejs/node/issues/2098
+          process.kill(this.spawnedProcess.pid + 1)
+        }
+        if (exitCode === null) {
+          resolve()
+        } else {
+          reject('The process exited unexpectedly\n' + this.printExecResult())
+        }
+      }, 500)
+    })
+  }
+
+  assertProcessExitedWithCode(expectedExitCode) {
+    return this.ensureProcessHasExited().then(() => {
+      assert.equal(this.spawnedProcess.exitCode, expectedExitCode, this.printExecResult())
+    })
+  }
+
+  assertOutputIncludes(expectedOutput, stream = 'output') {
+    return this.ensureProcessHasExited().then(() => {
+      const normalisedExpectedOutput = expectedOutput.replace('\r\n', '\n')
+      const normalisedActualOutput = colors.strip(this.execResult[stream]).replace('\r\n', '\n')
+      if (normalisedActualOutput.indexOf(normalisedExpectedOutput) == -1) {
+        throw new Error(`Expected ${stream} to include:\n${normalisedExpectedOutput}\n` +
+          this.printExecResult())
+      }
+    })
+  }
+
+  assertStdoutIncludes(expectedOutput) {
+    return this.assertOutputIncludes(expectedOutput, 'stdout')
+  }
+
+  assertStderrIncludes(expectedOutput) {
+    // On windows, everything goes out of stderr. Electron.exe needs a shim, or something
+    const errorStream = os.platform() === 'win32' ? 'stdout' : 'stderr'
+    return this.assertOutputIncludes(expectedOutput, errorStream)
+  }
+}
+
+module.exports = Processes

--- a/features/support/worlds/webApps.js
+++ b/features/support/worlds/webApps.js
@@ -1,0 +1,71 @@
+const http = require('http')
+const assert = require('assert')
+
+class WebApps {
+  stop() {
+    if (this.webAppServer) {
+      return new Promise((resolve, reject) => {
+        this.webAppServer.close(function (e) {
+          e ? reject(e) : resolve()
+        })
+      })
+    } else {
+      return Promise.resolve()
+    }
+  }
+
+  runWebApp() {
+    let session = 1
+    return new Promise((resolve, reject) => {
+      this.webAppServer = http.createServer((req, res) => {
+        if (req.url == '/') {
+          res.writeHead(302, {
+            'Set-Cookie': ['session=' + (session++) + '; expires=0; path=/;"'],
+            'Connection': 'close',
+            'Location': '/content'
+          })
+          res.end()
+        } else if (req.url == '/content') {
+          res.writeHead(200, {
+            'Content-Type': 'text/html',
+            'Connection': 'close',
+          })
+          res.end('<script>document.write(document.cookie)</' + 'script>')
+        } else {
+          res.writeHead(404)
+          res.end()
+        }
+      })
+      this.webAppServer.listen(8666, error => {
+        error ? reject(error) : resolve()
+      })
+    })
+  }
+
+  loadWebAppInIFrame(url) {
+    const frame = document.createElement('iframe')
+    frame.src = url
+    document.body.appendChild(frame)
+    document.body.appendChild(document.createElement('br'))
+    return new Promise(function (resolve) {
+      frame.onload = function () {
+        resolve(frame)
+      }
+    })
+  }
+
+  reloadFrame(frame) {
+    return new Promise(function (resolve) {
+      frame.onload = function () {
+        resolve()
+      }
+      frame.contentWindow.location.reload()
+    })
+  }
+
+  assertFrameIsInSession(frame, session) {
+    assert.equal(frame.contentDocument.body.innerText, 'session=' + session)
+  }
+}
+
+module.exports = WebApps

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cucumber-electron": "./bin/cucumber-electron.js"
   },
   "scripts": {
-    "test": "cucumber-js && node ./bin/cucumber-electron.js && npm run eslint",
+    "test": "cucumber-js --tags 'not @only-runs-in-cucumber-electron' && node ./bin/cucumber-electron.js && npm run eslint",
     "eslint": "eslint '**/*.js' --ignore 'node_modules/**/*.js'"
   },
   "author": "Josh Chisholm <joshuachisholm@gmail.com>",


### PR DESCRIPTION
Hey @aslakhellesoy - I made this quick example of hosting a web app in the renderer process and then accessing it with two independent sessions, isolated by using different hostnames (localhost and 127.0.0.1). It's a bit messy, but it works. Of course, it's not quite the same as multiple browser windows but I think it could get you a long way in certain cases, without resorting to multiple processes.

Do you think we need to make this easier in cucumber-electron?

It's fairly trivial, for example, to map the hostname `*.cucumber` to `127.0.0.1` for any requests made by electron. Or we could add support for loading your web app in iframes (and waiting for them to load) if most users will need to do this. I'm just not sure either is really cucumber-electron's responsibility. Maybe delegate this stuff to some other library?