### PR TITLE
Don't bundle electron with cucumber-electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Runs [cucumber-js](https://github.com/cucumber/cucumber-js) in an [electron](htt
 
 ## Install
 
-    npm install cucumber-electron --save-dev
+    npm install electron cucumber-electron --save-dev
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "ansi-to-html": "0.6.0",
     "commander": "2.9.0",
     "cucumber": "2.0.0-rc.7",
-    "electron": "1.4.15",
     "electron-window": "0.8.1",
     "gherkin": "4.0.0"
   },
@@ -26,6 +25,7 @@
   },
   "devDependencies": {
     "colors": "^1.1.2",
+    "electron": "1.6.2",
     "eslint": "^3.15.0",
     "fs-promise": "^2.0.0",
     "mkdirp-promise": "^5.0.1",


### PR DESCRIPTION
So that users can control what version of electron to use.

Fixes #8 