### PR TITLE
Upgrade to Electron 1.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,6 @@
       "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
       "dev": true
     },
-    "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
-      "dev": true
-    },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -70,9 +64,9 @@
       "dev": true
     },
     "ansi-to-html": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.2.tgz",
-      "integrity": "sha1-34uqzyAdh+/xsaS2nLRHPTSxkOY=",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.3.tgz",
+      "integrity": "sha512-EAhxLited8575DW57wt0csRYUrwjpNErgOPc5KJIyY7YD41AuqBy9CAuWyuQYLPUUtmoPzHYxgFKGPniKpgEig==",
       "requires": {
         "entities": "1.1.1"
       }
@@ -496,9 +490,9 @@
       }
     },
     "cucumber": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-3.0.4.tgz",
-      "integrity": "sha512-ZvhphKO/ofIqiaNKexA9eOAKzIiYjX5mKDwHW5f9RqRqrlberA0IZERPMGPYT0DmwKD4e3G6Cta3MLn9US7cLw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-3.1.0.tgz",
+      "integrity": "sha512-DW5vY0oDTY3XtpPx8fYoKtro1JnMr7dOngZv6Ix53aJ4xhKViI/Yxbk3Q7Jaiw618/7uh1aw1RL6xKC67VyC6A==",
       "dev": true,
       "requires": {
         "assertion-error-formatter": "2.0.0",
@@ -507,12 +501,12 @@
         "cli-table": "0.3.1",
         "colors": "1.1.2",
         "commander": "2.11.0",
-        "cucumber-expressions": "4.0.4",
+        "cucumber-expressions": "5.0.13",
         "cucumber-tag-expressions": "1.0.1",
         "duration": "0.2.0",
         "escape-string-regexp": "1.0.5",
         "figures": "2.0.0",
-        "gherkin": "4.1.3",
+        "gherkin": "5.0.0",
         "glob": "7.1.2",
         "indent-string": "3.2.0",
         "is-generator": "1.0.3",
@@ -521,21 +515,35 @@
         "mz": "2.7.0",
         "progress": "2.0.0",
         "resolve": "1.4.0",
-        "stack-chain": "1.3.7",
+        "stack-chain": "2.0.0",
         "stacktrace-js": "2.0.0",
         "string-argv": "0.0.2",
         "title-case": "2.1.1",
         "util-arity": "1.1.0",
         "verror": "1.10.0"
-      }
-    },
-    "cucumber-expressions": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-4.0.4.tgz",
-      "integrity": "sha512-FWZDGuQ8WhZVLoweOf5adKDwqFF/NFI/Y4JlZt5ds99ExJ6h/BkHW5X6kugjf+KL4df/PUIOqSR1KthOXsFvpw==",
-      "dev": true,
-      "requires": {
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
+      },
+      "dependencies": {
+        "cucumber-expressions": {
+          "version": "5.0.13",
+          "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.13.tgz",
+          "integrity": "sha1-8XRZfa5tLwEhKUrC6mVEMknPFYc=",
+          "dev": true,
+          "requires": {
+            "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
+          }
+        },
+        "gherkin": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.0.0.tgz",
+          "integrity": "sha1-lt70EZjsOQgli1Ea909lWidk0qE=",
+          "dev": true
+        },
+        "stack-chain": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+          "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
+          "dev": true
+        }
       }
     },
     "cucumber-tag-expressions": {
@@ -625,24 +633,6 @@
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
-    "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
-      }
-    },
     "duration": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
@@ -664,9 +654,9 @@
       }
     },
     "electron": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.8.tgz",
-      "integrity": "sha1-J7eRpolRcafVKZG5lELNvRCjU50=",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
+      "integrity": "sha1-mTtqp54OeafPzDafTIE/vZoLCNk=",
       "dev": true,
       "requires": {
         "@types/node": "7.0.43",
@@ -788,33 +778,33 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
-      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.12.0.tgz",
+      "integrity": "sha512-Ohv4NU0FffkEe4so8DBrdfRUbGUtM4XnBTDll2pY7OdW3VkjBOZPerx3Bmuhg6S6D6r8+cli0EezN0xawUfYwg==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -832,6 +822,24 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -846,6 +854,31 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "espree": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.3.0",
+            "acorn-jsx": "3.0.1"
+          }
+        },
+        "globals": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
@@ -881,16 +914,6 @@
       "requires": {
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
-      }
-    },
-    "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
-      "dev": true,
-      "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -986,6 +1009,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1125,12 +1154,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "gherkin": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-4.1.3.tgz",
-      "integrity": "sha1-EWh9uTl235djMSWmsiKKGkv9+iQ=",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1144,12 +1167,6 @@
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
       }
-    },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
     },
     "globby": {
       "version": "5.0.0",
@@ -1512,6 +1529,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2291,12 +2314,6 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
-    },
-    "stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
-      "dev": true
     },
     "stack-generator": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "colors": "1.1.2",
     "cucumber": "3.1.0",
-    "electron": "1.7.9",
+    "electron": "1.7.11",
     "eslint": "4.12.0",
     "fs-promise": "2.0.3",
     "mkdirp-promise": "5.0.1",


### PR DESCRIPTION
This PR upgrades to Electron 1.7.11, following the **security recommendation** in GitHub's vulnerability tracking.

- `npm test` passed locally
- the package lock file has cucumber-expressions 5.0.13