### PR TITLE
Rename --electron-debug to --interactive (or -i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run cucumber-electron it like it was cucumber-js, for example:
     ./node_modules/.bin/cucumber-electron ./features/your.feature:123
 
 
-## Debugging
+## Interactive Debugging
 
-The `--electron-debug` command line switch shows a browser window with chrome dev tools and keeps
+The `--interactive` (or `-i`) command line switch shows a browser window with chrome dev tools and keeps
 the window open after all features have finished running.

--- a/cli/options.js
+++ b/cli/options.js
@@ -1,6 +1,6 @@
 class Options {
   constructor(argv) {
-    this.cucumberArgv = argv.filter(a => a != '--electron-debug')
+    this.cucumberArgv = argv.filter(a => a != '--interactive' && a != '-i' && a != '--interactive')
     this.electronDebug = argv.length > this.cucumberArgv.length
   }
 }

--- a/features/node_and_browser.feature
+++ b/features/node_and_browser.feature
@@ -35,5 +35,5 @@ Feature: Node and browser
     Then the process should exit with code 0
 
   Scenario: Debugging a scenario with node.js and browser step definitions
-    When I run `cucumber-electron --electron-debug`
+    When I run `cucumber-electron --interactive`
     Then the process should not exit

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -32,8 +32,8 @@ When('I run `cucumber-electron`', function () {
   return this.runCommand('cucumber-electron')
 })
 
-When('I run `cucumber-electron --electron-debug`', function () {
-  return this.runCommand('cucumber-electron --electron-debug')
+When('I run `cucumber-electron --interactive`', function () {
+  return this.runCommand('cucumber-electron --interactive')
 })
 
 When('I run `cucumber-electron --tags @a`', function () {


### PR DESCRIPTION
The name `--electron-debug` was chosen to avoid any potential conflict with future options passed to the cucumber-js CLI. But other electron tools tend to use `--interactive` for the same behaviour, and both are annoying to type, so this renames `--electron-debug` to `--interactive` and allows `-i` as a shorthand. We can revisit if cucumber-js uses `-i` in future :)