### PR TITLE
CLI --help

### DIFF
--- a/bin/cucumber-electron.js
+++ b/bin/cucumber-electron.js
@@ -6,16 +6,28 @@ var path = require('path')
 var electron = require('electron')
 
 var args = process.argv.slice(2)
-args.unshift(path.resolve(path.join(__dirname, '../index.js')))
+if (args.length === 1 && args[0] === '--help' || args[0] === '-h') {
+  showHelp()
+} else {
+  runCucumberInRendererProcess()
+}
 
-var child = spawn(electron, args)
-child.stdout.pipe(process.stdout)
-process.stdin.pipe(child.stdin)
+function showHelp() {
+  require('../cli/help')
+}
 
-child.stderr.on('data', function (data) {
-  var str = data.toString('utf8')
-  // Mute irrelevant chromium errors
-  if (str.match(/^\[\d+:\d+/)) return
-  process.stderr.write(data)
-})
-child.on('exit', function (code) { process.exit(code) })
+function runCucumberInRendererProcess() {
+  args.unshift(path.resolve(path.join(__dirname, '../index.js')))
+
+  var child = spawn(electron, args)
+  child.stdout.pipe(process.stdout)
+  process.stdin.pipe(child.stdin)
+
+  child.stderr.on('data', function (data) {
+    var str = data.toString('utf8')
+    // Mute irrelevant chromium errors
+    if (str.match(/^\[\d+:\d+/)) return
+    process.stderr.write(data)
+  })
+  child.on('exit', function (code) { process.exit(code) })
+}

--- a/cli/help.js
+++ b/cli/help.js
@@ -1,0 +1,23 @@
+const Cucumber = require('cucumber')
+
+const write = process.stdout.write
+process.stdout.write = (chunk, ...args) => {
+  chunk = chunk.split('\n').map(rewriteExitLine).join('\n')
+  write.call(process.stdout, chunk, ...args)
+}
+
+function rewriteExitLine(line) {
+  if (line.match(/\s+--exit/) == null) {
+    return line
+  }
+  return [
+    '    --exit                          UNSUPPORTED in cucumber-electron: force shutdown of the event loop when the test run has finished',
+    '    -i, --interactive               open an interactive debugger (chromium dev tools)'
+  ].join('\n')
+}
+
+new Cucumber.Cli({
+  argv: ['node', 'cucumber-electron', '--help'],
+  cwd: process.cwd(),
+  stdout: process.stdout
+}).run()

--- a/features/help.feature
+++ b/features/help.feature
@@ -1,0 +1,7 @@
+Feature: Help
+  Scenario: Running the CLI with --help
+    When I run `cucumber-electron --help`
+    Then stdout should include "Usage: cucumber-electron"
+    And stdout should include "--interactive"
+    And stdout should include "UNSUPPORTED in cucumber-electron: force shutdown of the event loop"
+    And stdout should include "For more details please visit https://github.com/cucumber/cucumber-js#cli"

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -56,6 +56,10 @@ When('I run `cucumber-electron --tags @b`', function () {
   return this.runCommand('cucumber-electron --tags @b')
 })
 
+When('I run `cucumber-electron --help`', function () {
+  return this.runCommand('cucumber-electron --help')
+})
+
 Then('the process should exit with code {int}', function (exitCode) {
   return this.assertProcessExitedWithCode(exitCode)
 })


### PR DESCRIPTION
Hijacks the `--help` CLI behaviour from cucumber-js with some evil monkey patching, and tweaks it to mention the fact that `--exit` is unsupported, and that `--interactive` is an option