### PR TITLE
Revert "Bump jquery from 3.3.1 to 3.5.0 in /examples/angularjs"

### DIFF
--- a/examples/angularjs/yarn.lock
+++ b/examples/angularjs/yarn.lock
@@ -566,8 +566,8 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 jquery@^3.2.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Reverts cucumber/cucumber-electron#41