### PR TITLE
Add new --stylesheet [PATH] option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Added
 
+* Add `--stylesheet [PATH]` option to load a custom stylesheet
 * Add a AppElements API that can be used in step definitions and hooks
 * Add TypeScript definitions for API
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ The interactive debugger will halt execution on any `debugger` statements, or br
 
 In interactive mode you can re-run all your scenarios by pressing `CMD-R` (MacOS) or `CTRL-R` (Windows/Linux)
 while the browser window has focus.
+
+## Custom Stylesheet
+
+You can add a custom stylesheet to the DOM with the `--stylesheet [PATH]` option.

--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -6,6 +6,7 @@ const rewriteExitLine = line =>
     : [
         '    --exit                          UNSUPPORTED in cucumber-electron: force shutdown of the event loop when the test run has finished',
         '    -i, --interactive               open an interactive debugger (chromium dev tools)',
+        '    --stylesheet [PATH]             load the stylesheet specified by [PATH]',
       ].join('\n')
 
 runCli(rewriteExitLine)

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -1,8 +1,18 @@
 class Options {
   constructor(argv) {
+    this.stylesheet = optArg(argv, '--stylesheet')
     this.interactiveMode = Boolean(argv.find(isInteractiveSwitch))
     this.isTTY = Boolean(argv.find(isTTYSwitch))
     this.cucumberArgv = argv.filter(arg => !isInteractiveSwitch(arg) && !isTTYSwitch(arg))
+  }
+}
+
+function optArg(argv, opt) {
+  const optIndex = argv.findIndex(arg => arg === opt)
+  if (optIndex !== -1) {
+    const value = argv[optIndex + 1]
+    argv.splice(optIndex, 2)
+    return value
   }
 }
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -6,6 +6,7 @@ const options = new Options(remote.process.argv)
 
 require('./patches/console')
 require('./keyboard/bindings')
+require('./stylesheet')
 
 const Cucumber = require('@cucumber/cucumber')
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,6 +1,6 @@
 // This is the main entry point for the electron process
-const { join } = require('path')
-const url = require('url')
+const { join, resolve } = require('path')
+const { pathToFileURL } = require('url')
 const { app, ipcMain: ipc, BrowserWindow } = require('electron')
 app.commandLine.appendSwitch('--disable-http-cache')
 
@@ -56,11 +56,11 @@ app.whenReady().then(() => {
     app.dock.hide()
   }
 
-  const indexPath = url.format({
-    protocol: 'file',
-    slashes: true,
-    pathname: join(__dirname, 'index.html'),
-  })
+  const url = pathToFileURL(join(__dirname, `index.html`))
+  if (options.stylesheet) {
+    url.searchParams.set('stylesheet', resolve(options.stylesheet))
+  }
+  const indexPath = url.href
   win.loadURL(indexPath)
 })
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1,0 +1,66 @@
+body {
+    background-color: #222;
+    color: #fff;
+}
+
+pre {
+    margin: 0;
+    display: inline
+}
+
+.cucumber-electron-fake-browser {
+    padding-bottom: 10px;
+}
+
+.cucumber-electron-fake-browser-dot {
+    height: 10px;
+    width: 10px;
+    border-radius: 50%;
+    border-style: solid;
+    border-width: 1px;
+    display: inline-block;
+}
+
+.cucumber-electron-fake-browser-red {
+    background-color: #ed6a5f;
+    border-color: #d15449;
+}
+
+.cucumber-electron-fake-browser-orange {
+    background-color: #f5bf50;
+    border-color: #d7a345;
+}
+
+.cucumber-electron-fake-browser-green {
+    background-color: #62c654;
+    border-color: #55a943;
+}
+
+.cucumber-electron-fake-browser-title {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: small;
+    color: #000000;
+    padding-left: 4px;
+    vertical-align: top;
+}
+
+.cucumber-electron-fake-browser-top {
+    padding: 8px 6px 6px 8px;
+    border-radius: 4px 4px 0 0;
+    border-top: 1px solid;
+    border-left: 1px solid;
+    border-right: 1px solid;
+    background-color: #dee1e6;
+    border-color: #dee1e6;
+}
+
+.cucumber-electron-fake-browser-content {
+    padding: 6px;
+    border-radius: 0 0 4px 4px;
+    border-bottom: 1px solid;
+    border-left: 1px solid;
+    border-right: 1px solid;
+    background-color: #ffffff;
+    border-color: #ffffff;
+    color: #000000;
+}

--- a/src/renderer/stylesheet/index.js
+++ b/src/renderer/stylesheet/index.js
@@ -1,0 +1,12 @@
+const stylesheet = new URL(window.location).searchParams.get('stylesheet')
+
+if (stylesheet) {
+  const head = document.head
+  const link = document.createElement('link')
+
+  link.type = 'text/css'
+  link.rel = 'stylesheet'
+  link.href = stylesheet
+
+  head.appendChild(link)
+}


### PR DESCRIPTION
This is useful when the mounted components don't embed their own stylesheets and relies on a stylesheet to be loaded in `<head>`