### PR TITLE
Allow using AppElements as a type

### DIFF
--- a/@types/cucumber-electron/api/index.d.ts
+++ b/@types/cucumber-electron/api/index.d.ts
@@ -1,3 +1,2 @@
-export var AppElements: {
-    new (): import("./AppElements");
-};
+export { AppElements };
+import AppElements = require("./AppElements");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
-* Fix `TS2749: 'AppElements' refers to a value, but is being used as a type here. Did you mean 'typeof AppElements'?`
+* [#70](https://github.com/cucumber/cucumber-electron/pull/70)
+  Fix `TS2749: 'AppElements' refers to a value, but is being used as a type here. Did you mean 'typeof AppElements'?`
   when using `AppElements` as a type.
 
 ## [4.1.1] - 2021-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blo
 
 ### Fixed
 
+* Fix `TS2749: 'AppElements' refers to a value, but is being used as a type here. Did you mean 'typeof AppElements'?`
+  when using `AppElements` as a type.
+
 ## [4.1.1] - 2021-06-23
 
 ### Fixed

--- a/src/renderer/api/index.js
+++ b/src/renderer/api/index.js
@@ -1,1 +1,5 @@
-module.exports.AppElements = require('./AppElements')
+const AppElements = require('./AppElements')
+
+module.exports = {
+  AppElements,
+}

--- a/test/AppElements.test.ts
+++ b/test/AppElements.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { JSDOM } from 'jsdom'
-import { AppElements } from '..'
+import { AppElements } from '../src'
 
 describe('AppElements', () => {
   it('creates an app element', () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,15 @@
+// Using '..' is important in order to verify types
+import { AppElements } from ".."
+import assert from "assert"
+
+describe('types', () => {
+  describe('AppElements', () => {
+    it('can be used as a type', () => {
+      function assertAppElements(appElements: AppElements) {
+        assert(appElements)
+      }
+      const appElements = new AppElements()
+      assertAppElements(appElements)
+    })
+  })
+})


### PR DESCRIPTION
# Description

Using `AppElements` as a type in a function parameter gives the error `TS2749: 'AppElements' refers to a value, but is being used as a type here. Did you mean 'typeof AppElements'?`

# Motivation & context

I want to use it as a type

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)
- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors

Follow the pattern in `src/renderer/api/index.js` if new classes and types are added to the API

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
